### PR TITLE
refactor: some pre refactorings for floating point features

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,5 @@ DerivePointerAlignment: false
 Standard: c++20
 ColumnLimit: 120
 AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: None
 IndentRequiresClause: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,14 +204,14 @@ jobs:
       - name: Build
         run: cmake --build build/test/size_test -j $(nproc)
 
-      - name: Build
+      - name: Size-Coverage
         run: cmake --build build -t size-coverage
 
   size-test-embedded:
     runs-on: ubuntu-22.04
 
     env:
-      DOWNLOAD_LINK: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+      DOWNLOAD_LINK: https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
 
     steps:
       - uses: actions/checkout@v3
@@ -220,13 +220,13 @@ jobs:
         id: cache-toolchain
         uses: actions/cache@v2
         with:
-          path: gcc-arm-none-eabi-10.3-2021.10
+          path: arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi
           key: ${{ env.DOWNLOAD_LINK }}
 
       - name: Install GCC ARM none eabi
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
-          curl -L $DOWNLOAD_LINK | tar xj
+          curl -L $DOWNLOAD_LINK | tar xJ
 
       - name: Configure
         run: cmake --preset=ci-size-coverage-embedded -DCMAKE_BUILD_TYPE=MinSizeRel
@@ -237,8 +237,8 @@ jobs:
       - name: Size-Coverage
         run: cmake --build build -t size-coverage
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: build/test/size_test/size-coverage.info
+#      - name: Coveralls - Doesn't work.
+#        uses: coverallsapp/github-action@master
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          path-to-lcov: build/test/size_test/size-coverage.info

--- a/cmake/arm-none-eabi-toolchain.cmake
+++ b/cmake/arm-none-eabi-toolchain.cmake
@@ -6,7 +6,7 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY) # do not link executable when testing the compiler.
 
-set(TOOLCHAIN_BIN_PATH ${CMAKE_CURRENT_SOURCE_DIR}/gcc-arm-none-eabi-10.3-2021.10/bin)
+set(TOOLCHAIN_BIN_PATH ${CMAKE_CURRENT_SOURCE_DIR}/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi/bin)
 
 set(CMAKE_C_COMPILER ${TOOLCHAIN_BIN_PATH}/arm-none-eabi-gcc)
 set(CMAKE_CXX_COMPILER ${TOOLCHAIN_BIN_PATH}/arm-none-eabi-g++)

--- a/include/emio/detail/conversion.hpp
+++ b/include/emio/detail/conversion.hpp
@@ -56,6 +56,7 @@ constexpr char digit_to_char(int digit, int base, bool upper) noexcept {
 }
 
 template <typename T>
+  requires(std::is_unsigned_v<T>)
 constexpr size_t count_digits_10(T number) noexcept {
   size_t count = 1;
   for (;;) {
@@ -80,6 +81,7 @@ constexpr size_t count_digits_10(T number) noexcept {
 }
 
 template <size_t Base, typename T>
+  requires(std::is_unsigned_v<T>)
 constexpr size_t count_digits(T number) noexcept {
   if (number == 0) {
     return 1;

--- a/include/emio/detail/format/formatter.hpp
+++ b/include/emio/detail/format/formatter.hpp
@@ -110,7 +110,9 @@ template <typename Arg>
   requires(std::is_integral_v<Arg> && !std::is_same_v<Arg, bool> && !std::is_same_v<Arg, char>)
 constexpr result<void> write_arg(writer<char>& wtr, format_specs& specs, const Arg& arg) noexcept {
   if (specs.type == 'c') {
-    return write_padded<alignment::left>(wtr, specs, 1, [&] { return wtr.write_char(static_cast<char>(arg)); });
+    return write_padded<alignment::left>(wtr, specs, 1, [&] {
+      return wtr.write_char(static_cast<char>(arg));
+    });
   }
   EMIO_TRY((auto [prefix, options]), make_write_int_options(specs.type));
 
@@ -193,9 +195,13 @@ constexpr result<void> write_arg(writer<char>& wtr, format_specs& specs, const A
 
 inline constexpr result<void> write_arg(writer<char>& wtr, format_specs& specs, const std::string_view arg) noexcept {
   if (specs.type != '?') {
-    return write_padded<alignment::left>(wtr, specs, arg.size(), [&] { return wtr.write_str(arg); });
+    return write_padded<alignment::left>(wtr, specs, arg.size(), [&] {
+      return wtr.write_str(arg);
+    });
   }
-  return write_padded<alignment::left>(wtr, specs, arg.size() + 2U, [&] { return wtr.write_str_escaped(arg); });
+  return write_padded<alignment::left>(wtr, specs, arg.size() + 2U, [&] {
+    return wtr.write_str_escaped(arg);
+  });
 }
 
 template <typename Arg>
@@ -206,9 +212,13 @@ constexpr result<void> write_arg(writer<char>& wtr, format_specs& specs, const A
     return write_arg(wtr, specs, static_cast<uint8_t>(arg));
   }
   if (specs.type != '?') {
-    return write_padded<alignment::left>(wtr, specs, 1, [&] { return wtr.write_char(arg); });
+    return write_padded<alignment::left>(wtr, specs, 1, [&] {
+      return wtr.write_char(arg);
+    });
   }
-  return write_padded<alignment::left>(wtr, specs, 3, [&] { return wtr.write_char_escaped(arg); });
+  return write_padded<alignment::left>(wtr, specs, 3, [&] {
+    return wtr.write_char_escaped(arg);
+  });
 }
 
 template <typename Arg>
@@ -228,9 +238,13 @@ constexpr result<void> write_arg(writer<char>& wtr, format_specs& specs, Arg arg
     return write_arg(wtr, specs, static_cast<uint8_t>(arg));
   }
   if (arg) {
-    return write_padded<alignment::left>(wtr, specs, 4, [&] { return wtr.write_str("true"); });
+    return write_padded<alignment::left>(wtr, specs, 4, [&] {
+      return wtr.write_str("true");
+    });
   }
-  return write_padded<alignment::left>(wtr, specs, 5, [&] { return wtr.write_str("false"); });
+  return write_padded<alignment::left>(wtr, specs, 5, [&] {
+    return wtr.write_str("false");
+  });
 }
 
 //
@@ -459,7 +473,7 @@ template <typename T>
 concept has_validate_function_v = requires {
                                     {
                                       formatter<T>::validate(std::declval<reader<char>&>())
-                                      } -> std::same_as<result<void>>;
+                                    } -> std::same_as<result<void>>;
                                   };
 
 template <typename T>

--- a/include/emio/detail/format/formatter.hpp
+++ b/include/emio/detail/format/formatter.hpp
@@ -473,7 +473,7 @@ template <typename T>
 concept has_validate_function_v = requires {
                                     {
                                       formatter<T>::validate(std::declval<reader<char>&>())
-                                    } -> std::same_as<result<void>>;
+                                      } -> std::same_as<result<void>>;
                                   };
 
 template <typename T>

--- a/include/emio/detail/predef.hpp
+++ b/include/emio/detail/predef.hpp
@@ -34,11 +34,13 @@ namespace emio::detail {
   }                                          \
   EMIO_Z_INTERNAL_DEPAREN(var) = std::move(name).assume_value()
 
-// Separate macro instead of std::is_constant_evaluated() because code will be optimized away even in debug if inlined.
 #if defined(__GNUC__) || defined(__GNUG__) || defined(_MSC_VER)
+// Separate macro instead of std::is_constant_evaluated() because code will be optimized away even in debug if inlined.
 #  define Y_EMIO_IS_CONST_EVAL __builtin_is_constant_evaluated()
+#  define EMIO_Z_INTERNAL_UNREACHABLE __builtin_unreachable()
 #else
 #  define Y_EMIO_IS_CONST_EVAL std::is_constant_evaluated()
+#  define EMIO_Z_INTERNAL_UNREACHABLE std::terminate()
 #endif
 
 }  // namespace emio::detail

--- a/include/emio/result.hpp
+++ b/include/emio/result.hpp
@@ -109,7 +109,7 @@ inline constexpr bool exceptions_disabled = true;
     std::terminate();
 #endif
   }
-  __builtin_unreachable();
+  EMIO_Z_INTERNAL_UNREACHABLE;
 }
 
 }  // namespace detail

--- a/test/unit_test/test_reader.cpp
+++ b/test/unit_test/test_reader.cpp
@@ -285,7 +285,9 @@ TEST_CASE("reader::read_until", "[reader]") {
   SECTION("read_until") {
     emio::reader reader{"a12bcd"};
 
-    auto res = reader.read_until([](char c) { return c == 'b'; });
+    auto res = reader.read_until([](char c) {
+      return c == 'b';
+    });
     CHECK(res == "a12");
   }
 }


### PR DESCRIPTION
To make it better comparable.

Switching from GCC 10.3 to GCC 11.3 increased the binary size for all test cases.
* emio ~ 300 bytes
* fmt ~ 457 bytes
