### PR TITLE
refactor(scan): reduce code usage

### DIFF
--- a/include/emio/detail/args.hpp
+++ b/include/emio/detail/args.hpp
@@ -28,9 +28,9 @@ class validation_arg {
   // No destructor & delete call to concept_t because model_t holds only a reference.
   ~validation_arg() = default;
 
-  result<void> validate(reader& scan_is) const noexcept {
+  result<void> validate(reader& format_rdr) const noexcept {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): only way to get the object back
-    return reinterpret_cast<const concept_t*>(&storage_)->validate(scan_is);
+    return reinterpret_cast<const concept_t*>(&storage_)->validate(format_rdr);
   }
 
  private:
@@ -42,7 +42,7 @@ class validation_arg {
     concept_t& operator=(const concept_t&) = delete;
     concept_t& operator=(concept_t&&) = delete;
 
-    virtual result<void> validate(reader& scan_is) const noexcept = 0;
+    virtual result<void> validate(reader& format_rdr) const noexcept = 0;
 
    protected:
     ~concept_t() = default;
@@ -57,8 +57,8 @@ class validation_arg {
     model_t& operator=(const model_t&) = delete;
     model_t& operator=(model_t&&) = delete;
 
-    result<void> validate(reader& scan_is) const noexcept override {
-      return Trait<std::remove_cvref_t<T>>::validate(scan_is);
+    result<void> validate(reader& format_rdr) const noexcept override {
+      return Trait<std::remove_cvref_t<T>>::validate(format_rdr);
     }
 
    protected:
@@ -87,9 +87,9 @@ class arg {
   arg& operator=(arg&&) = delete;
   ~arg() = default;  // No destructor & delete call to concept_t because model_t holds only a reference.
 
-  result<void> process_arg(Input& input, reader& scan_is) const noexcept {
+  result<void> process_arg(Input& input, reader& format_rdr) const noexcept {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast): only way to get the object back
-    return reinterpret_cast<const concept_t*>(&storage_)->process_arg(input, scan_is);
+    return reinterpret_cast<const concept_t*>(&storage_)->process_arg(input, format_rdr);
   }
 
  private:
@@ -101,7 +101,7 @@ class arg {
     concept_t& operator=(const concept_t&) = delete;
     concept_t& operator=(concept_t&&) = delete;
 
-    virtual result<void> process_arg(Input& input, reader& scan_is) const noexcept = 0;
+    virtual result<void> process_arg(Input& input, reader& format_rdr) const noexcept = 0;
 
    protected:
     ~concept_t() = default;
@@ -117,8 +117,8 @@ class arg {
     model_t& operator=(const model_t&) = delete;
     model_t& operator=(model_t&&) = delete;
 
-    result<void> process_arg(Input& input, reader& scan_is) const noexcept override {
-      return Trait<std::remove_cvref_t<T>>::process_arg(input, scan_is, value_);
+    result<void> process_arg(Input& input, reader& format_rdr) const noexcept override {
+      return Trait<std::remove_cvref_t<T>>::process_arg(input, format_rdr, value_);
     }
 
    protected:

--- a/include/emio/detail/conversion.hpp
+++ b/include/emio/detail/conversion.hpp
@@ -153,13 +153,12 @@ template <typename T>
 using uint32_or_64 = std::conditional_t<num_bits<T>() <= 32, uint32_t, uint64_t>;
 
 template <typename T>
+using upcasted_int_t = std::conditional_t<std::is_signed_v<T>, int32_or_64<T>, uint32_or_64<T>>;
+
+template <typename T>
   requires(std::is_integral_v<T>)
 constexpr auto integer_upcast(T integer) {
-  if constexpr (std::is_signed_v<T>) {
-    return static_cast<int32_or_64<T>>(integer);
-  } else {
-    return static_cast<uint32_or_64<T>>(integer);
-  }
+  return static_cast<upcasted_int_t<T>>(integer);
 }
 
 template <typename T>

--- a/include/emio/detail/format/formatter.hpp
+++ b/include/emio/detail/format/formatter.hpp
@@ -784,8 +784,9 @@ concept has_any_validate_function_v =
 
 template <typename T>
 inline constexpr bool is_core_type_v =
-    std::is_integral_v<T> || std::is_floating_point_v<T> || std::is_same_v<T, std::nullptr_t> ||
-    std::is_same_v<T, void*> || std::is_same_v<T, std::string_view>;
+    std::is_same_v<T, bool> || std::is_same_v<T, char> || std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t> ||
+    std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t> || std::is_same_v<T, double> ||
+    std::is_same_v<T, std::nullptr_t> || std::is_same_v<T, void*> || std::is_same_v<T, std::string_view>;
 
 template <typename T>
 concept has_format_as = requires(T arg) { format_as(arg); };

--- a/include/emio/detail/scan/args.hpp
+++ b/include/emio/detail/scan/args.hpp
@@ -33,28 +33,9 @@ struct scan_arg_trait {
   }
 
   static constexpr result<void> process_arg(reader& in, reader& format_rdr, Arg& arg) noexcept {
-    if constexpr (std::is_integral_v<Arg> && !std::is_same_v<Arg, bool> && !std::is_same_v<Arg, char>) {
-      using upcast_int_t = decltype(detail::integer_upcast(Arg{}));
-      if constexpr (std::is_same_v<upcast_int_t, Arg>) {
-        scanner<Arg> scanner;
-        EMIO_TRYV(scanner.parse(format_rdr));
-        return scanner.scan(in, arg);
-      } else {
-        // Check if upcast int is within the integer type range.
-        upcast_int_t val{};
-        EMIO_TRYV(scan_arg_trait<upcast_int_t>::process_arg(in, format_rdr, val));
-        if (val < std::numeric_limits<Arg>::min() || val > std::numeric_limits<Arg>::max()) {
-          return err::out_of_range;
-        }
-        arg = static_cast<Arg>(val);
-        return success;
-      }
-    } else {
-      scanner<Arg> scanner;
-      EMIO_TRYV(scanner.parse(format_rdr));
-      return scanner.scan(in, arg);
-    }
-
+    scanner<Arg> scanner;
+    EMIO_TRYV(scanner.parse(format_rdr));
+    return scanner.scan(in, arg);
   }
 };
 

--- a/include/emio/detail/scan/scanner.hpp
+++ b/include/emio/detail/scan/scanner.hpp
@@ -326,8 +326,8 @@ inline constexpr bool has_scanner_v = std::is_constructible_v<scanner<Arg>>;
 
 template <typename T>
 concept has_validate_function_v = requires {
-  { scanner<T>::validate(std::declval<reader&>()) } -> std::same_as<result<void>>;
-};
+                                    { scanner<T>::validate(std::declval<reader&>()) } -> std::same_as<result<void>>;
+                                  };
 
 template <typename T>
 concept has_any_validate_function_v =

--- a/include/emio/detail/scan/scanner.hpp
+++ b/include/emio/detail/scan/scanner.hpp
@@ -326,8 +326,8 @@ inline constexpr bool has_scanner_v = std::is_constructible_v<scanner<Arg>>;
 
 template <typename T>
 concept has_validate_function_v = requires {
-                                    { scanner<T>::validate(std::declval<reader&>()) } -> std::same_as<result<void>>;
-                                  };
+  { scanner<T>::validate(std::declval<reader&>()) } -> std::same_as<result<void>>;
+};
 
 template <typename T>
 concept has_any_validate_function_v =
@@ -335,7 +335,9 @@ concept has_any_validate_function_v =
     requires { std::declval<scanner<T>>().validate(std::declval<reader&>()); };
 
 template <typename T>
-inline constexpr bool is_core_type_v = !std::is_same_v<T, bool> && std::is_integral_v<T>;
+inline constexpr bool is_core_type_v =
+    std::is_same_v<T, char> || std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t> ||
+    std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>;
 
 }  // namespace detail::scan
 

--- a/include/emio/reader.hpp
+++ b/include/emio/reader.hpp
@@ -197,17 +197,17 @@ class reader {
     const size_t backup_pos = pos_;
 
     // Reduce code generation by upcasting the integer.
-    using upcast_int_t = decltype(detail::integer_upcast(T{}));
-    const result<upcast_int_t> res = parse_sign_and_int<upcast_int_t>(base);
+    using upcasted_t = detail::upcasted_int_t<T>;
+    const result<upcasted_t> res = parse_sign_and_int<upcasted_t>(base);
     if (!res) {
       pos_ = backup_pos;
       return res.assume_error();
     }
-    if constexpr (std::is_same_v<upcast_int_t, T>) {
+    if constexpr (std::is_same_v<upcasted_t, T>) {
       return res;
     } else {
       // Check if upcast int is within the integer type range.
-      const upcast_int_t val = res.assume_value();
+      const upcasted_t val = res.assume_value();
       if (val < std::numeric_limits<T>::min() || val > std::numeric_limits<T>::max()) {
         pos_ = backup_pos;
         return err::out_of_range;

--- a/include/emio/scanner.hpp
+++ b/include/emio/scanner.hpp
@@ -102,8 +102,7 @@ class scanner<T> {
  * Scanner for integral types which are not core types.
  */
 template <typename T>
-  requires(std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t> || std::is_same_v<T, int16_t> ||
-           std::is_same_v<T, uint16_t>)
+  requires(std::is_integral_v<T> && !std::is_same_v<T, bool> && !detail::scan::is_core_type_v<T>)
 class scanner<T> : public scanner<detail::upcasted_int_t<T>> {
  private:
   using upcasted_t = detail::upcasted_int_t<T>;

--- a/include/emio/scanner.hpp
+++ b/include/emio/scanner.hpp
@@ -102,7 +102,8 @@ class scanner<T> {
  * Scanner for integral types which are not core types.
  */
 template <typename T>
-  requires(std::is_integral_v<T> && !detail::scan::is_core_type_v<T>)
+  requires(std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t> || std::is_same_v<T, int16_t> ||
+           std::is_same_v<T, uint16_t>)
 class scanner<T> : public scanner<detail::upcasted_int_t<T>> {
  private:
   using upcasted_t = detail::upcasted_int_t<T>;
@@ -118,6 +119,7 @@ class scanner<T> : public scanner<detail::upcasted_int_t<T>> {
     return success;
   }
 };
+
 /**
  * Scanner for std::string_view.
  */

--- a/include/emio/scanner.hpp
+++ b/include/emio/scanner.hpp
@@ -99,6 +99,26 @@ class scanner<T> {
 };
 
 /**
+ * Scanner for integral types which are not core types.
+ */
+template <typename T>
+  requires(std::is_integral_v<T> && !detail::scan::is_core_type_v<T>)
+class scanner<T> : public scanner<detail::upcasted_int_t<T>> {
+ private:
+  using upcasted_t = detail::upcasted_int_t<T>;
+
+ public:
+  constexpr result<void> scan(reader& in, T& arg) noexcept {
+    upcasted_t val{};
+    EMIO_TRYV(scanner<upcasted_t>::scan(in, val));
+    if (val < std::numeric_limits<T>::min() || val > std::numeric_limits<T>::max()) {
+      return err::out_of_range;
+    }
+    arg = static_cast<T>(val);
+    return success;
+  }
+};
+/**
  * Scanner for std::string_view.
  */
 template <>

--- a/test/unit_test/integer_ranges.hpp
+++ b/test/unit_test/integer_ranges.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+namespace emio::test {
+
+inline constexpr std::tuple integer_ranges{
+    std::tuple{
+        std::type_identity<bool>{},
+        std::tuple{"1", "0", "-1", "-10"},
+        std::tuple{"0", "1", "2", "10"},
+    },
+    std::tuple{
+        std::type_identity<int8_t>{},
+        std::tuple{"-127", "-128", "-129", "-1280"},
+        std::tuple{"126", "127", "128", "1270"},
+    },
+    std::tuple{
+        std::type_identity<uint8_t>{},
+        std::tuple{"1", "0", "-1", "-10"},
+        std::tuple{"254", "255", "256", "2550"},
+    },
+    std::tuple{
+        std::type_identity<int16_t>{},
+        std::tuple{"-32767", "-32768", "-32769", "-327680"},
+        std::tuple{"32766", "32767", "327678", "327670"},
+    },
+    std::tuple{
+        std::type_identity<uint16_t>{},
+        std::tuple{"1", "0", "-1", "-10"},
+        std::tuple{"65534", "65535", "65536", "655350"},
+    },
+    std::tuple{
+        std::type_identity<int32_t>{},
+        std::tuple{"-2147483647", "-2147483648", "-2147483649", "-21474836480"},
+        std::tuple{"2147483646", "2147483647", "2147483648", "21474836470"},
+    },
+    std::tuple{
+        std::type_identity<uint32_t>{},
+        std::tuple{"1", "0", "-1", "-10"},
+        std::tuple{"4294967294", "4294967295", "4294967296", "42949672950"},
+    },
+    std::tuple{
+        std::type_identity<int64_t>{},
+        std::tuple{"-9223372036854775807", "-9223372036854775808", "-9223372036854775809", "-92233720368547758080"},
+        std::tuple{"9223372036854775806", "9223372036854775807", "9223372036854775808", "-92233720368547758070"},
+    },
+    std::tuple{
+        std::type_identity<uint64_t>{},
+        std::tuple{"1", "0", "-1", "-10"},
+        std::tuple{"18446744073709551614", "18446744073709551615", "18446744073709551616", "184467440737095516150"},
+    },
+};
+
+template <typename T>
+constexpr void apply_integer_ranges(T&& func) {
+  std::apply(
+      [&](auto... inputs) {
+        (std::apply(func, inputs), ...);
+      },
+      integer_ranges);
+}
+
+}  // namespace emio::test

--- a/test/unit_test/test_reader.cpp
+++ b/test/unit_test/test_reader.cpp
@@ -2,6 +2,7 @@
 #include <emio/reader.hpp>
 
 // Other includes.
+#include "integer_ranges.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
@@ -92,54 +93,6 @@ TEST_CASE("reader::parse_int", "[reader]") {
   // Expected: The method works as expected.
 
   SECTION("min/max cases") {
-    constexpr std::tuple ranges{
-        std::tuple{
-            std::type_identity<bool>{},
-            std::tuple{"1", "0", "-1", "-10"},
-            std::tuple{"0", "1", "2", "10"},
-        },
-        std::tuple{
-            std::type_identity<int8_t>{},
-            std::tuple{"-127", "-128", "-129", "-1280"},
-            std::tuple{"126", "127", "128", "1270"},
-        },
-        std::tuple{
-            std::type_identity<uint8_t>{},
-            std::tuple{"1", "0", "-1", "-10"},
-            std::tuple{"254", "255", "256", "2550"},
-        },
-        std::tuple{
-            std::type_identity<int16_t>{},
-            std::tuple{"-32767", "-32768", "-32769", "-327680"},
-            std::tuple{"32766", "32767", "327678", "327670"},
-        },
-        std::tuple{
-            std::type_identity<uint16_t>{},
-            std::tuple{"1", "0", "-1", "-10"},
-            std::tuple{"65534", "65535", "65536", "655350"},
-        },
-        std::tuple{
-            std::type_identity<int32_t>{},
-            std::tuple{"-2147483647", "-2147483648", "-2147483649", "-21474836480"},
-            std::tuple{"2147483646", "2147483647", "2147483648", "21474836470"},
-        },
-        std::tuple{
-            std::type_identity<uint32_t>{},
-            std::tuple{"1", "0", "-1", "-10"},
-            std::tuple{"4294967294", "4294967295", "4294967296", "42949672950"},
-        },
-        std::tuple{
-            std::type_identity<int64_t>{},
-            std::tuple{"-9223372036854775807", "-9223372036854775808", "-9223372036854775809", "-92233720368547758080"},
-            std::tuple{"9223372036854775806", "9223372036854775807", "9223372036854775808", "-92233720368547758070"},
-        },
-        std::tuple{
-            std::type_identity<uint64_t>{},
-            std::tuple{"1", "0", "-1", "-10"},
-            std::tuple{"18446744073709551614", "18446744073709551615", "18446744073709551616", "184467440737095516150"},
-        },
-    };
-
     const auto range_check = []<typename T>(std::type_identity<T> /*type*/, const auto& lower_input,
                                             const auto& upper_input) {
       CHECK(emio::reader{std::get<0>(lower_input)}.parse_int<T>() == std::numeric_limits<T>::min() + 1);
@@ -152,11 +105,7 @@ TEST_CASE("reader::parse_int", "[reader]") {
       CHECK(emio::reader{std::get<2>(upper_input)}.parse_int<T>() == emio::err::out_of_range);
       CHECK(emio::reader{std::get<3>(upper_input)}.parse_int<T>() == emio::err::out_of_range);
     };
-    std::apply(
-        [&](auto... inputs) {
-          (std::apply(range_check, inputs), ...);
-        },
-        ranges);
+    emio::test::apply_integer_ranges(range_check);
   }
 
   SECTION("sign is correctly parsed") {

--- a/test/unit_test/test_reader.cpp
+++ b/test/unit_test/test_reader.cpp
@@ -2,9 +2,10 @@
 #include <emio/reader.hpp>
 
 // Other includes.
-#include "integer_ranges.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+
+#include "integer_ranges.hpp"
 
 using namespace std::string_view_literals;
 

--- a/test/unit_test/test_scan.cpp
+++ b/test/unit_test/test_scan.cpp
@@ -2,8 +2,9 @@
 #include <emio/scan.hpp>
 
 // Other includes.
-#include "integer_ranges.hpp"
 #include <catch2/catch_test_macros.hpp>
+
+#include "integer_ranges.hpp"
 
 namespace {
 

--- a/test/unit_test/test_scan.cpp
+++ b/test/unit_test/test_scan.cpp
@@ -286,7 +286,7 @@ TEST_CASE("integral with width", "[scan]") {
   REQUIRE(emio::scan("+0x5", "{:#3}5", val) == emio::err::eof);
 }
 
-TEST_CASE("integral with different types", "[scan]") {
+TEST_CASE("scan integral of different types", "[scan]") {
   const auto range_check = []<typename T>(std::type_identity<T> /*type*/, const auto& lower_input,
                                           const auto& upper_input) {
     if constexpr (!std::is_same_v<T, bool>) {

--- a/test/unit_test/test_scan.cpp
+++ b/test/unit_test/test_scan.cpp
@@ -284,6 +284,23 @@ TEST_CASE("integral with width", "[scan]") {
   REQUIRE(emio::scan("+0x5", "{:#3}5", val) == emio::err::eof);
 }
 
+TEST_CASE("integral with different types", "[scan]") {
+  int8_t i8{};
+  uint8_t u8{};
+  int16_t i16{};
+  uint16_t u16{};
+  int32_t i32{};
+  uint32_t u32{};
+  int64_t i64{};
+  uint64_t u64{};
+  REQUIRE(emio::scan("1 2 3 4 5 6 7 8", "{} {} {} {} {} {} {} {}", i8, u8, i16, u16, i32, u32, i64, u64));
+  CHECK(i8 == 1);
+  CHECK(u8 == 2);
+  CHECK(i16 == 3);
+  CHECK(u16 == 4);
+  CHECK(u64 == 8);
+}
+
 TEST_CASE("scan_binary", "[scan]") {
   int val{};
   SECTION("no prefix") {


### PR DESCRIPTION

* emio_size_test_emio_format_and_scan_all.cpp: 18192 - 16480 = **1712**
* emio_size_test_emio_scan_all.cpp: 7712 - 5776 = **1936**
* emio_size_test_emio_scan_int.cpp: 2912 - 2916 = **-4** (because of int != int32_t ?)