### PR TITLE
fix: add missing includes for emscripten compiler

### DIFF
--- a/include/emio/result.hpp
+++ b/include/emio/result.hpp
@@ -9,8 +9,10 @@
 #include <concepts>
 #include <cstdint>
 #include <optional>
+#include <string_view>
 #if __STDC_HOSTED__
 #  include <stdexcept>
+#  include <string>
 #endif
 #include <type_traits>
 


### PR DESCRIPTION
Tested with Emscripten, clang-16